### PR TITLE
fix install script buf

### DIFF
--- a/buf.sh
+++ b/buf.sh
@@ -9,7 +9,7 @@ INSTALL_VERSION=${INSTALL_VERSION:-0.24.0}
 download() {
   OS_NAME=$(uname -s)
   DOWNLOAD_URL="https://github.com/bufbuild/buf/releases/download/v${INSTALL_VERSION}/buf-${OS_NAME}-x86_64.tar.gz"
-  curl -sfL "${DOWNLOAD_URL}" | tar -C "$INSTALL_DIR" -xz --strip-components=2 --wildcards "buf/bin/*"
+  curl -sSL "${DOWNLOAD_URL}" | tar -xvzf - -C "$INSTALL_DIR" --strip-components 1
 }
 
 if [ ! -f "$INSTALL_BIN" ]; then

--- a/buf.sh
+++ b/buf.sh
@@ -8,7 +8,8 @@ INSTALL_VERSION=${INSTALL_VERSION:-0.24.0}
 
 download() {
   OS_NAME=$(uname -s)
-  DOWNLOAD_URL="https://github.com/bufbuild/buf/releases/download/v${INSTALL_VERSION}/buf-${OS_NAME}-x86_64.tar.gz"
+  HARDWARE_NAME=$(uname -m)
+  DOWNLOAD_URL="https://github.com/bufbuild/buf/releases/download/v${INSTALL_VERSION}/buf-${OS_NAME}-${HARDWARE_NAME}.tar.gz"
   curl -sSL "${DOWNLOAD_URL}" | tar -xvzf - -C "$INSTALL_DIR" --strip-components 2
 }
 

--- a/buf.sh
+++ b/buf.sh
@@ -9,7 +9,7 @@ INSTALL_VERSION=${INSTALL_VERSION:-0.24.0}
 download() {
   OS_NAME=$(uname -s)
   DOWNLOAD_URL="https://github.com/bufbuild/buf/releases/download/v${INSTALL_VERSION}/buf-${OS_NAME}-x86_64.tar.gz"
-  curl -sSL "${DOWNLOAD_URL}" | tar -xvzf - -C "$INSTALL_DIR" --strip-components 1
+  curl -sSL "${DOWNLOAD_URL}" | tar -xvzf - -C "$INSTALL_DIR" --strip-components 2
 }
 
 if [ ! -f "$INSTALL_BIN" ]; then


### PR DESCRIPTION
fix tar extraction command as current command is break is macOS
<img width="649" alt="image" src="https://user-images.githubusercontent.com/23008578/160564868-2135c95a-86ec-4113-b646-3dc677063128.png">


ref: https://docs.buf.build/installation#tarball